### PR TITLE
iOS: Fix URL corruption during navigation transitions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cat:*)",
+      "Bash(xargs cat:*)",
+      "Bash(wc:*)",
+      "Bash(find:*)",
+      "Bash(npx turbo lint)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -81,7 +81,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   lazy var controller: RNVisitableViewController? = RNVisitableViewController(reactViewController: reactViewController(), delegate: self)
     
   private var isRefreshing: Bool {
-    controller!.visitableView.isRefreshing
+    controller?.visitableView.isRefreshing ?? false
   }
     
   private func configureWebView() {
@@ -112,12 +112,17 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     webViewUrlObservation = webView?.observe(\.url, options: [.new]) { [weak self] webView, change in
             guard let self = self,
                   let newUrl = change.newValue ?? nil,
-                  let controller = self.controller else { return }
-            
+                  let controller = self.controller,
+                  // Only update URL if this controller is still the active visitable.
+                  // Otherwise, a deactivated visitable's URL gets corrupted when the
+                  // shared WebView navigates for a different visitable.
+                  self.session?.turboSession.activeVisitable === controller
+                  else { return }
+
             if controller.visitableURL != newUrl {
                 controller.visitableURL = newUrl
             }
-        }   
+        }
     }
     
     private func stopObservingWebViewUrl() {
@@ -299,6 +304,8 @@ extension RNVisitableView: RNVisitableViewControllerDelegate {
   }
     
   func visitableWillDisappear(visitable: Visitable) {
+    stopObservingWebViewUrl()
+
     // Ensure that all completion handlers have been called.
     // Otherwise, an NSInternalInconsistencyException might occur.
     sendAlertResult()
@@ -306,7 +313,6 @@ extension RNVisitableView: RNVisitableViewControllerDelegate {
   }
 
   func visitableDidDisappear(visitable: Visitable) {
-    stopObservingWebViewUrl()
   }
 
   func visitableDidRender(visitable: Visitable) {


### PR DESCRIPTION
## Summary

- Fix URL corruption causing wrong screen content on back navigation
- Fix `isRefreshing` force-unwrap crash (Sentry DATING-APP-AJ, 479 events, 86 users)

## Root cause

The shared WebView URL observation (`webViewUrlObservation`) updates `controller.visitableURL` for ALL observing RNVisitableViews, not just the active one. During forward navigation, React's `didSetProps` triggers the new visit ~38ms before UIKit's `viewWillDisappear` stops the observation. In that window, the old screen's observation fires and overwrites its URL with the new screen's URL.

When navigating back, `Session.visitableViewWillAppear` reads the corrupted URL and issues a restore visit to the wrong page.

**Repro:** Landing → Sign in → back → Landing shows Sign in content instead

## Fixes

1. **Guard URL observation** with `session.activeVisitable === controller` — only the visitable that currently owns the WebView should have its URL updated
2. **Move `stopObservingWebViewUrl()`** from `visitableDidDisappear` to `visitableWillDisappear` for earlier cleanup
3. **Fix `isRefreshing` crash** — `controller!` → `controller?` when controller is nil after `removeFromSuperview()`

## Test plan

- [ ] Open Landing page → tap Sign in → press back → verify Landing shows correct content
- [ ] Tap forward again → verify correct page loads (not Sign in)
- [ ] Pull-to-refresh still works correctly after Turbo Frame navigations
- [ ] No crash on rapid back navigation