### PR TITLE
Android: Fix crash when measure runs after view detachment

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableView.kt
@@ -250,11 +250,13 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   }
 
   private val measureAndLayout = Runnable {
-    measure(
-      MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-      MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
-    )
-    layout(left, top, right, bottom)
+    if (isAttachedToWindow) {
+      measure(
+        MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+        MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+      )
+      layout(left, top, right, bottom)
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes a fatal `IllegalStateException` crash on Android where `HotwireSwipeRefreshLayout#onMeasure()` fails to call `setMeasuredDimension()`.

The `requestLayout()` override posts a `measureAndLayout` Runnable as a workaround for [facebook/react-native#17968](https://github.com/facebook/react-native/issues/17968). When the view is detached between the `post()` call and the Runnable execution, the child view hierarchy is no longer valid, causing the crash.

The fix guards the Runnable with `isAttachedToWindow`, matching the same approach used by RevenueCat for the identical issue: [RevenueCat/react-native-purchases#994](https://github.com/RevenueCat/react-native-purchases/issues/994) / [RevenueCat/react-native-purchases#1120](https://github.com/RevenueCat/react-native-purchases/pull/1120).

## Stack trace

```
IllegalStateException: View with id 2131231005:
  dev.hotwire.navigation.views.HotwireSwipeRefreshLayout#onMeasure()
  did not set the measured dimension by calling setMeasuredDimension()

  at View.measure (View.java:27162)
  at ViewGroup.measureChildWithMargins (ViewGroup.java:7086)
  at FrameLayout.onMeasure (FrameLayout.java:198)
  ...
  at RNVisitableView.measureAndLayout$lambda$13 (RNVisitableView.kt:253)
```