### PR TITLE
Android: Fix crash when measure runs after view detachment

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableView.kt
@@ -250,11 +250,13 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   }
 
   private val measureAndLayout = Runnable {
-    measure(
-      MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-      MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
-    )
-    layout(left, top, right, bottom)
+    if (isAttachedToWindow) {
+      measure(
+        MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+        MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+      )
+      layout(left, top, right, bottom)
+    }
   }
 
   /**


### PR DESCRIPTION
Guard the posted measureAndLayout runnable with isAttachedToWindow to prevent IllegalStateException when the view has been detached before the posted Runnable executes.

The requestLayout/post(measure) pattern is a workaround for facebook/react-native#17968. When the view is removed between the post() call and the Runnable execution, child views (specifically HotwireSwipeRefreshLayout) crash because their view hierarchy is no longer valid.

See also: RevenueCat/react-native-purchases#994