### PR TITLE
Android: Fix blank screen when reopening a fullScreenModal

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableView.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.runBlocking
 
 const val REFRESH_SCRIPT = "typeof Turbo.session.refresh === 'function'" +
         "? Turbo.session.refresh(document.baseURI)" + // Turbo 8+
-        ": Turbo.visit(document.baseURI, { action: 'replace', shouldCacheSnapshot: 'false' })" // Older Turbo versions 
+        ": Turbo.visit(document.baseURI, { action: 'replace', shouldCacheSnapshot: 'false' })" // Older Turbo versions
 
 class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscriber {
 
@@ -218,7 +218,20 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     // bottom tabs. In this case, we need to remove the webview from
     // the parent before attaching it to the new one.
     if (webView!!.parent != null) {
-      (webView!!.parent as ViewGroup).removeView(webView)
+      val parent = webView!!.parent as ViewGroup
+      parent.endViewTransition(webView!!)
+      parent.removeView(webView)
+
+      // When a fullScreenModal is dismissed, the react-native-screens
+      // Fragment animation may remove the webView from its parent's
+      // children array without clearing its mParent field. In that state,
+      // removeView() silently fails (indexOfChild returns -1) and no
+      // public API can clear mParent. Use the reparent helper to claim
+      // temporary ownership via the protected attachViewToParent(), then
+      // remove normally — leaving mParent properly null.
+      if (webView!!.parent != null) {
+        WebViewReparentHelper(reactContext).clearGhostParent(webView!!)
+      }
     }
 
     // Re-layout the HotwireView before attaching to make page restorations work correctly.

--- a/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/WebViewReparentHelper.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/WebViewReparentHelper.kt
@@ -1,0 +1,39 @@
+package com.reactnativehotwirewebview
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+
+/**
+ * Workaround for ghost parent references on Android.
+ *
+ * When a fullScreenModal (react-native-screens) is dismissed, the Fragment
+ * animation system may remove the WebView from its parent's children array
+ * without clearing the WebView's mParent field. In that state:
+ * - removeView() silently fails (indexOfChild returns -1)
+ * - addView() throws IllegalStateException ("already has a parent")
+ * - mParent cannot be cleared via reflection (hidden API restriction)
+ *
+ * This helper uses the protected ViewGroup.attachViewToParent() method to
+ * temporarily claim ownership of the view (overwriting the ghost mParent),
+ * then removes it normally — leaving mParent properly null.
+ */
+class WebViewReparentHelper(context: Context) : FrameLayout(context) {
+
+  fun clearGhostParent(child: View) {
+    val params = child.layoutParams
+      ?: ViewGroup.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT,
+        ViewGroup.LayoutParams.MATCH_PARENT
+      )
+
+    // attachViewToParent is protected and sets child.mParent = this
+    // without checking if mParent is already set.
+    attachViewToParent(child, 0, params)
+
+    // Now child IS in our mChildren array and mParent == this.
+    // removeView will find it (indexOfChild >= 0) and properly null mParent.
+    removeView(child)
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a bug where reopening a `fullScreenModal` (react-native-screens) on Android shows a blank screen that doesn't load and can't be refreshed. Requires a force-close to recover.

**Root cause:** When a fullScreenModal is dismissed, the Fragment animation system removes the shared WebView from its container's `mChildren` array without clearing the `mParent` field. This "ghost parent" reference causes `HotwireView.attachWebView()` to bail out on the next modal open (`attachedToNewDestination=false`), so no Turbo visit is ever initiated.

**Why standard APIs fail:**
- `removeView()` — silently fails because `indexOfChild()` returns -1
- `removeAllViews()` — only iterates `mChildren`, same issue
- `clearDisappearingChildren()` — doesn't null out `mParent`
- `endViewTransition()` — no-op when `mTransitioningViews` is null
- Reflection on `mParent` — blocked by Android hidden API restriction (targetSdk 28+)

**Fix:** `WebViewReparentHelper` uses the protected `ViewGroup.attachViewToParent()` to temporarily claim ownership of the WebView (overwriting the ghost `mParent`), then `removeView()` to properly null it out.